### PR TITLE
ENS mirror initial refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git submodule update --init --recursive
 In a terminal, start a ganache blockchain
 
 ```bash
-ganache-cli -p 8549
+./run-ganache.sh
 ```
 
 Open another terminal, start autocompiling smart-contracts

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ In a terminal, start a ganache blockchain
 ./run-ganache.sh
 ```
 
+_(note that this uses docker and will try to pull `trufflesuite/ganache-cli:v6.12.1` image if you don't have it)_
+
 Open another terminal, start autocompiling smart-contracts
 
 ```bash

--- a/resources/public/contracts/src/AuctionOfferingFactory.sol
+++ b/resources/public/contracts/src/AuctionOfferingFactory.sol
@@ -13,7 +13,7 @@ import "Forwarder.sol";
 contract AuctionOfferingFactory is OfferingFactory {
 
     function AuctionOfferingFactory(
-        ENS ens,
+        ENSRegistry ens,
         OfferingRegistry offeringRegistry,
         OfferingRequestsAbstract offeringRequests
     )

--- a/resources/public/contracts/src/BuyNowOfferingFactory.sol
+++ b/resources/public/contracts/src/BuyNowOfferingFactory.sol
@@ -13,7 +13,7 @@ import "Forwarder.sol";
 contract BuyNowOfferingFactory is OfferingFactory {
 
     function BuyNowOfferingFactory(
-        ENS ens,
+        ENSRegistry ens,
         OfferingRegistry offeringRegistry,
         OfferingRequestsAbstract offeringRequests
     )

--- a/resources/public/contracts/src/NameBazaarRegistrar.sol
+++ b/resources/public/contracts/src/NameBazaarRegistrar.sol
@@ -9,7 +9,7 @@ contract NameBazaarRegistrar is Registrar {
      * @param ens The address of the ENS
      * @param rootNode The hash of the rootnode.
      */
-    function NameBazaarRegistrar(AbstractENS ens, bytes32 rootNode, uint startDate) Registrar(ens, rootNode, startDate) public {}
+    function NameBazaarRegistrar(ENS ens, bytes32 rootNode, uint startDate) Registrar(ens, rootNode, startDate) public {}
 
     /**
      * @dev Convenience function added by NameBazaar for instant registration
@@ -20,7 +20,7 @@ contract NameBazaarRegistrar is Registrar {
     function register(bytes32 _hash) payable {
         Deed bid = (new Deed).value(msg.value)(msg.sender);
         sealedBids[msg.sender][bytes32(0)] = bid;
-        entry newAuction = _entries[_hash];
+        Entry newAuction = _entries[_hash];
         newAuction.registrationDate = now - 6 days;
         newAuction.value = msg.value;
         newAuction.highestBid = msg.value;

--- a/resources/public/contracts/src/Offering.sol
+++ b/resources/public/contracts/src/Offering.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.4.18;
  * @dev Contains base logic for an offering and is meant to be extended.
  */
 
-import "ens-repo/contracts/ENS.sol";
+import "ens-repo/contracts/ENSRegistry.sol";
 import "ens-repo/contracts/HashRegistrarSimplified.sol";
 import "OfferingRegistry.sol";
 
@@ -28,7 +28,7 @@ contract Offering {
     Offering public offering;
 
     // Hardcoded ENS address. For development will be replaced after compilation. This way we save gas to users deploying offering contracts.
-    ENS public constant ens = ENS(0x314159265dD8dbb310642f98f50C066173C1259b);
+    ENSRegistry public constant ens = ENSRegistry(0x314159265dD8dbb310642f98f50C066173C1259b);
 
     // Hardcoded namehash of "eth"
     bytes32 public constant rootNode = 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae;
@@ -87,7 +87,7 @@ contract Offering {
         require(!isContractNodeOwner());
         _;
     }
-    
+
     /**
      * @dev Constructor of offering
      * Should be callable just once, by factory
@@ -113,10 +113,10 @@ contract Offering {
         offering.price = _price;
     }
 
-   /**
-    * @dev Unregisters offering for not displaying it in UI
-    * Cannot be run if contract has ownership or it was already transferred to new owner
-    */
+    /**
+     * @dev Unregisters offering for not displaying it in UI
+     * Cannot be run if contract has ownership or it was already transferred to new owner
+     */
     function unregister()
         public
         onlyOriginalOwner
@@ -128,7 +128,7 @@ contract Offering {
         offering.newOwner = 0xdeaddead;
         fireOnChanged("unregister");
     }
-    
+
     /**
     * @dev Transfers ENS name ownership back to original owner
     * Can be run only by original owner or emergency multisig

--- a/resources/public/contracts/src/OfferingFactory.sol
+++ b/resources/public/contracts/src/OfferingFactory.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.18;
 
-import "ens-repo/contracts/ENS.sol";
+import "ens-repo/contracts/ENSRegistry.sol";
 import "ens-repo/contracts/HashRegistrarSimplified.sol";
 import "OfferingRegistry.sol";
 import "OfferingRequestsAbstract.sol";
@@ -14,7 +14,7 @@ import "strings.sol";
 contract OfferingFactory {
     using strings for *;
 
-    ENS public ens;
+    ENSRegistry public ens;
     OfferingRegistry public offeringRegistry;
     OfferingRequestsAbstract public offeringRequests;
 
@@ -22,7 +22,7 @@ contract OfferingFactory {
     bytes32 public constant rootNode = 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae;
 
     function OfferingFactory (
-        ENS _ens,
+        ENSRegistry _ens,
         OfferingRegistry _offeringRegistry,
         OfferingRequestsAbstract _offeringRequests
     ) {

--- a/run-ganache.sh
+++ b/run-ganache.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker stop namebazaar-ganache || true
+docker rm namebazaar-ganache || true
+
+docker run --name=namebazaar-ganache -d \
+    -p 8549:8549 \
+    trufflesuite/ganache-cli:v6.12.1 -p 8549

--- a/src/name_bazaar/shared/smart_contracts.cljs
+++ b/src/name_bazaar/shared/smart_contracts.cljs
@@ -22,7 +22,7 @@
    {:name "PublicResolver",
     :address "0x5FfC014343cd971B7eb70732021E26C35B744cc4"},
    :ens
-   {:name "ENS", :address "0x5c0a54e5d85d7422f47c0a4d877fe984aac1bf12"},
+   {:name "ENSRegistry", :address "0x5c0a54e5d85d7422f47c0a4d877fe984aac1bf12"},
    :offering-registry
    {:name "OfferingRegistry",
     :address "0xe22a7319429be44c75d15329c65643c19605c8d1"},


### PR DESCRIPTION
This should mirror the first changes in ENS smart contracts since Name Bazaar project stopped following them:

https://github.com/ensdomains/ens/commit/6141359670

Testing:
```
solc use <proper.solidity.version>
./compile-solidity.sh
./run-ganache.sh
lein doo node "server-tests"
```