### PR TITLE
Manage ENS dependency from lein npm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "resources/public/contracts/src/ens-repo"]
-	path = resources/public/contracts/src/ens-repo
-	url = https://github.com/ensdomains/ens.git
 [submodule "resources/public/contracts/src/strings-lib-repo"]
 	path = resources/public/contracts/src/strings-lib-repo
 	url = git@github.com:Arachnid/solidity-stringutils.git

--- a/README.md
+++ b/README.md
@@ -10,25 +10,6 @@ Smart-contracts can be found [here](https://github.com/district0x/name-bazaar/tr
 
 ## Starting a dev server with an Ethereum Testnet
 
-First, clone the project with submodules _([ens](https://github.com/ensdomains/ens))_
-
-```bash
-git clone --recurse-submodules https://github.com/district0x/name-bazaar.git
-```
-
-in case you already downloaded the repo, or forgot to clone the submodules, use
-```bash
-git submodule update --init --recursive
-```
-
-By default, working with submodules is tedious, and the defaults are not great
-either. Git doesn't checkout the submodules to the correct version (e.g. on pull,
-checkout) by default. You can override the git settings by:
-
-```bash
-git config --global submodule.recurse true
-```
-
 In a terminal, start a ganache blockchain
 
 ```bash
@@ -115,37 +96,6 @@ or
 `./semantic.sh watch`
 
 Depending upon how you'd like to work.
-
-## Updating ens contracts
-
-We use ENS as a submodule to track the dependency on it's contracts. If you are in
-`contracts/ens-repo` directory, you can use
-
-```bash
-git checkout master
-git pull origin master
-git checkout -
-git log --pretty=oneline --reverse --ancestry-path HEAD..master
-```
-
-to first update the ens repository and then list the commits in ens `master` branch, which are
-not in our version of `ens-repo`. _(You can use this list of commits when updating to the latest
-version of ens contracts)_
-
-Exemplary workflow may look like this:
-1) Running the commands above gives me the commits in ENS I want to update.
-   Let's say: `6141359670af83974340e6492e6830125783ccaa`
-
-2) You can then use `git checkout 6141359670af83974340e6492e6830125783ccaa`.
-   This will checkout the files of that commit.
-
-3) The namebazaar repository will report changes in this submodule when you
-   execute `git status` _(outside the ENS repo)_.
-
-4) These changes **should be** committed together with the update of
-   namebazaar code.
-
-For comprehensive guide on git submodules read: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 
 ## Start a development UI for client-side development only
 

--- a/compile-solidity.sh
+++ b/compile-solidity.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+ENS=$(readlink -f ./node_modules/@ensdomains)
+
 cd resources/public/contracts/src
 
 function solc-err-only {
-    solc "$@" 2>&1 | grep -A 2 -i "Error"
+    solc @ensdomains=$ENS "$@" 2>&1 | grep -A 2 -i "Error"
 }
 
 # TODO use script for this
@@ -12,9 +14,9 @@ solc-err-only --overwrite --optimize --bin --abi BuyNowOfferingFactory.sol -o ..
 solc-err-only --overwrite --optimize --bin --abi AuctionOfferingFactory.sol -o ../build/
 solc-err-only --overwrite --optimize --bin --abi District0xEmails.sol -o ../build/
 solc-err-only --overwrite --optimize --bin --abi OfferingRequests.sol -o ../build/
-solc-err-only --overwrite --optimize --bin --abi ens-repo/contracts/ENS.sol -o ../build/
-solc-err-only --overwrite --optimize --bin --abi ens-repo/contracts/PublicResolver.sol -o ../build/
-solc-err-only --overwrite --optimize --bin --abi ens-repo/contracts/ReverseRegistrar.sol -o ../build/
+solc-err-only --overwrite --optimize --bin --abi $ENS/ens/contracts/ENS.sol -o ../build/
+solc-err-only --overwrite --optimize --bin --abi $ENS/ens/contracts/PublicResolver.sol -o ../build/
+solc-err-only --overwrite --optimize --bin --abi $ENS/ens/contracts/ReverseRegistrar.sol -o ../build/
 solc-err-only --overwrite --optimize --bin --abi Forwarder.sol -o ../build/
 solc-err-only --overwrite --optimize --bin --abi NameBazaarRegistrar.sol -o ../build/
 

--- a/project.clj
+++ b/project.clj
@@ -73,7 +73,8 @@
             [lein-npm "0.6.2"]
             [lein-pdo "0.1.1"]]
 
-  :npm {:dependencies [["@sentry/node" "4.2.1"]
+  :npm {:dependencies [["@ensdomains/ens" "0.1.2"]
+                       ["@sentry/node" "4.2.1"]
                        [chalk "2.3.0"]
                        [eth-ens-namehash "2.0.0"]
                        [semantic-ui "2.4.1"]

--- a/resources/public/contracts/src/NameBazaarRegistrar.sol
+++ b/resources/public/contracts/src/NameBazaarRegistrar.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.18;
 
-import "./ens-repo/contracts/HashRegistrar.sol";
+import "@ensdomains/ens/contracts/HashRegistrar.sol";
 
 contract NameBazaarRegistrar is HashRegistrar {
     /**

--- a/resources/public/contracts/src/Offering.sol
+++ b/resources/public/contracts/src/Offering.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.4.18;
  * @dev Contains base logic for an offering and is meant to be extended.
  */
 
-import "ens-repo/contracts/ENSRegistry.sol";
-import "ens-repo/contracts/HashRegistrar.sol";
+import "@ensdomains/ens/contracts/ENSRegistry.sol";
+import "@ensdomains/ens/contracts/HashRegistrar.sol";
 import "OfferingRegistry.sol";
 
 contract Offering {

--- a/resources/public/contracts/src/OfferingFactory.sol
+++ b/resources/public/contracts/src/OfferingFactory.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.18;
 
-import "ens-repo/contracts/ENSRegistry.sol";
-import "ens-repo/contracts/HashRegistrar.sol";
+import "@ensdomains/ens/contracts/ENSRegistry.sol";
+import "@ensdomains/ens/contracts/HashRegistrar.sol";
 import "OfferingRegistry.sol";
 import "OfferingRequestsAbstract.sol";
 import "strings-lib-repo/strings.sol";


### PR DESCRIPTION
This may seem not pressing now, but later on we'll need 4 ensdomains github repositories as dependencies. Managing that as git submodules would become pretty dreadful afaik. Fortunately all of this is published on npm (I checked that latest ENS version is availabe there).