### PR TITLE
Small cljs fixes, downgrade district-server-smart-contracts to v1.0.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,13 @@
                  ;; in dev mode and tests. Later version removes deploy-smart-contract!
                  ;; function in favor of truffle migrations.
                  ;; TODO(not important): update to latest version
-                 [district0x/district-server-smart-contracts "1.0.10"]
+                 ;;
+                 ;; Versions up to 1.0.8 do not trigger errors in BE, but starting from
+                 ;; 1.0.9 function `get-offering` is being called with `nil` and there is
+                 ;; an web3 error + db error. However, until 1.0.9 it seems that contract
+                 ;; callbacks do not work at all. So there is a bug either way.
+                 ;; TODO: update to version 1.0.9
+                 [district0x/district-server-smart-contracts "1.0.8"]
                  ;; TODO: update to newer version. Updating to 1.1.0 breaks the tests
                  [district0x/district-server-web3 "1.0.1"]
                  [district0x/district-server-web3-watcher "1.0.3"]

--- a/src/name_bazaar/server/emailer.cljs
+++ b/src/name_bazaar/server/emailer.cljs
@@ -153,9 +153,9 @@
 
 
 (defn event-callback [f]
-  (fn [error res]
-    (if error
-      (error "Emailer got error from blockchain event" {:error error} ::event-callback)
+  (fn [err res]
+    (if err
+      (error "Emailer got error from blockchain event" {:error err} ::event-callback)
       (f (:args res)))))
 
 

--- a/src/name_bazaar/server/syncer.cljs
+++ b/src/name_bazaar/server/syncer.cljs
@@ -34,6 +34,8 @@
 
 
 (defn get-offering [offering-address]
+  ;; TODO: Why is this nil?
+  (assert (not= offering-address nil) "Offering address shouldn't be nil")
   (let [offering (offering/get-offering offering-address)
         auction-offering (when (:offering/auction? offering)
                            (auction-offering/get-auction-offering offering-address))

--- a/src/name_bazaar/shared/smart_contracts.cljs
+++ b/src/name_bazaar/shared/smart_contracts.cljs
@@ -1,37 +1,38 @@
 (ns name-bazaar.shared.smart-contracts)
 
 (def smart-contracts
-  {:auction-offering-factory
-   {:name "AuctionOfferingFactory",
-    :address "0x43f1481ca7876d49ac189d16e317a398b22a46d6"},
-   :buy-now-offering-factory
-   {:name "BuyNowOfferingFactory",
-    :address "0xeb84d5ab9c659779526e76e597c90467de468289"},
-   :name-bazaar-registrar
-   {:name "NameBazaarRegistrar",
-    :address "0x5ed7c4d6ba0f58e4ac0eacb4bbec98166018f3ea"},
-   :buy-now-offering
-   {:name "BuyNowOffering",
-    :address "0x8c8a52496b94581f1a8ce5d740ab02bcbb8a4d5a"},
-   :reverse-registrar
-   {:name "ReverseRegistrar",
-    :address "0x9062C0A6Dbd6108336BcBe4593a3D1cE05512069"},
-   :deed
-   {:name "Deed", :address "0x0000000000000000000000000000000000000000"},
-   :public-resolver
-   {:name "PublicResolver",
-    :address "0x5FfC014343cd971B7eb70732021E26C35B744cc4"},
-   :ens
-   {:name "ENSRegistry", :address "0x5c0a54e5d85d7422f47c0a4d877fe984aac1bf12"},
-   :offering-registry
-   {:name "OfferingRegistry",
-    :address "0xe22a7319429be44c75d15329c65643c19605c8d1"},
-   :district0x-emails
-   {:name "District0xEmails",
-    :address "0xbf8eee16a979d950926b300af61f4b0abf67277c"},
-   :offering-requests
-   {:name "OfferingRequests",
-    :address "0x7c2d5f61f0c9ce49cb2c8d436c187f7540beb286"},
-   :auction-offering
-   {:name "AuctionOffering",
-    :address "0xc49fab73e030dcbf31058ce6da263e63277b7489"}})
+{:auction-offering-factory
+ {:name "AuctionOfferingFactory",
+  :address "0xf6562dccfd2a135bf7eb8fe1a3279001ba33e84f"},
+ :buy-now-offering-factory
+ {:name "BuyNowOfferingFactory",
+  :address "0x3525181bf2ef29f0f86d6e049c2b5e331aa86754"},
+ :name-bazaar-registrar
+ {:name "NameBazaarRegistrar",
+  :address "0x02a4859792ff18bc611b7e34ef2eb8276070d544"},
+ :buy-now-offering
+ {:name "BuyNowOffering",
+  :address "0x8fc046ec87ee3fdc84836e98983561172b129416"},
+ :reverse-registrar
+ {:name "ReverseRegistrar",
+  :address "0x9062C0A6Dbd6108336BcBe4593a3D1cE05512069"},
+ :deed
+ {:name "Deed", :address "0x0000000000000000000000000000000000000000"},
+ :public-resolver
+ {:name "PublicResolver",
+  :address "0x5FfC014343cd971B7eb70732021E26C35B744cc4"},
+ :ens
+ {:name "ENSRegistry",
+  :address "0x468edc874e1fead4611b276608392dfb06f3f1c1"},
+ :offering-registry
+ {:name "OfferingRegistry",
+  :address "0x2f3b45084c8ca68b9ce175950f65ec2e67daa0cb"},
+ :district0x-emails
+ {:name "District0xEmails",
+  :address "0xeeb8c09e789ce3e63c7367af239bd8a17da058c4"},
+ :offering-requests
+ {:name "OfferingRequests",
+  :address "0x1a3bc2f94657a9dd364e8a01945e1c1c6db895aa"},
+ :auction-offering
+ {:name "AuctionOffering",
+  :address "0x450778e29c1cd2df801598d1e26cd77c1725af55"}})

--- a/src/name_bazaar/ui/components/offering/general_info.cljs
+++ b/src/name_bazaar/ui/components/offering/general_info.cljs
@@ -37,7 +37,7 @@
 
 
 (defn registrar-entry-deed-value-line [{:keys [:name-bazaar-registrar-entry]}]
-  (let [{:keys [:name-bazaar-registrar.entry.deed/address :name-bazaar-registrar.entry.deed/value]} registrar-entry]
+  (let [{:keys [:name-bazaar-registrar.entry.deed/address :name-bazaar-registrar.entry.deed/value]} name-bazaar-registrar-entry]
     [:div
      "Locked Value: " [etherscan-link
                        {:address address}


### PR DESCRIPTION
* The app works without problems with `district0x/district-server-smart-contracts` with version `1.0.8`, but starting from `1.0.9` the contract callback functions call our BE with unexpected data (`nil`). To reproduce it, you have to:
1) Start the app
2) In FE use instant registeration to register a domain
3) You should see errors in BE console
I believe the contract callbacks are not working until version `1.0.9`, so we have a problem either way. 
Version `1.0.9` is based on this PR: https://github.com/district0x/district-server-smart-contracts/commit/077340a7780ebbf5df2edda6f10573345020da5d, which changed the `contract-call` function. Hovewer, I do not understand why it caused such behaviour in namebazaar (TODO for us :/)
* For now rollbacked to version `1.0.8`
* Fixed `event-callback` error reporting. Previously the name `error` shadowed the error function which resulted in an error (that's also part of why we may have troubles debugging. After fixing that the error message got better).
* Found another typo in FE (but that is kinda unrelated to the main problem)