### PR TITLE
Fix compile solidity script

### DIFF
--- a/compile-solidity.sh
+++ b/compile-solidity.sh
@@ -11,6 +11,7 @@ function solc-err-only {
     solc @ensdomains=$ENS "openzeppelin-solidity"=$OZS "$@" 2>&1 | grep -A 2 -i "Error"
 }
 
+mkdir -p ../build
 solc-err-only --overwrite --optimize --bin --abi OfferingRegistry.sol -o ../build/
 solc-err-only --overwrite --optimize --bin --abi BuyNowOfferingFactory.sol -o ../build/
 solc-err-only --overwrite --optimize --bin --abi AuctionOfferingFactory.sol -o ../build/


### PR DESCRIPTION
Build directory must exist when running `compile-solidity.sh` and it's not created out of the box.
Since I added `build` dir into git ingore, it is not present on freshly created repository or when you remove it manually.