### PR TITLE
Configure client side router using :ring-handler

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -3,8 +3,22 @@
    [com.rpl.specter :as s]
    [figwheel-sidecar.repl-api :as fw-repl]
    [figwheel-sidecar.config :as fw-config]
-   [taoensso.timbre :as log]))
+   [taoensso.timbre :as log]
+   [compojure.core :refer [defroutes]]
+   [compojure.route :as route]
+   [ring.middleware.defaults :refer [site-defaults wrap-defaults]]))
 
+(defn- wrap-default-index [next-handler]
+  (fn [request]
+    (next-handler (assoc request :uri "/index.html"))))
+
+(defroutes routes (route/resources "/"))
+
+;; Inspired by https://github.com/bhauman/lein-figwheel/issues/344#issuecomment-243918040
+(def route-handler
+  "This function is responsible to serve index.html on every web route.
+  See :ring-handler in project.clj."
+  (wrap-defaults (wrap-default-index routes) site-defaults))
 
 (defn- set-closure-define
   "Sets the :closure-defines for the given `build-id` in the given

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -6,15 +6,24 @@
    [taoensso.timbre :as log]
    [compojure.core :refer [defroutes]]
    [compojure.route :as route]
-   [ring.middleware.defaults :refer [site-defaults wrap-defaults]]))
+   [ring.middleware.defaults :refer [site-defaults wrap-defaults]]
+   [clojure.string :refer [starts-with?]]))
 
 (defn- wrap-default-index [next-handler]
   (fn [request]
-    (next-handler (assoc request :uri "/index.html"))))
+    (next-handler
+      ;; whenever there is a request for asset, try to serve the asset
+      ;; otherwise fallback to index.html
+      (if (or (starts-with? (:uri request) "/css/")
+              (starts-with? (:uri request) "/js/")
+              (starts-with? (:uri request) "/images/"))
+        request
+        (assoc request :uri "/index.html")))))
 
 (defroutes routes (route/resources "/"))
 
-;; Inspired by https://github.com/bhauman/lein-figwheel/issues/344#issuecomment-243918040
+;; Inspired by https://github.com/bhauman/lein-figwheel/issues/344#issuecomment-374774199
+;; and also https://github.com/quangv/re-frame-html5-routing/pull/1
 (def route-handler
   "This function is responsible to serve index.html on every web route.
   See :ring-handler in project.clj."

--- a/project.clj
+++ b/project.clj
@@ -13,15 +13,16 @@
                  [cljsjs/react-infinite "0.13.0-0"]
                  [cljsjs/react-meta-tags "0.3.0-1"]
                  [com.rpl/specter "1.1.1"]
+                 [compojure "1.6.2"]
                  [day8.re-frame/async-flow-fx "0.0.8"]
                  [day8.re-frame/forward-events-fx "0.0.5"]
                  [honeysql "0.9.3"]
                  [medley "1.0.0"]
-                 ;; [org.clojure/clojurescript "1.9.946"]
                  [org.clojure/clojurescript "1.10.439"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [print-foo-cljs "2.0.3"]
                  [re-frame "0.10.6"]
+                 [ring/ring-defaults "0.3.2"]
                  ;; Can be removed when re-frame vbump includes reagent 8.0.1+
                  [reagent "0.8.1"]
                  [soda-ash "0.76.0"]
@@ -137,7 +138,8 @@
 
   :figwheel {:server-port 4544
              :css-dirs ["resources/public/css"]
-             :repl-eval-timeout 30000} ;; 30 seconds
+             :repl-eval-timeout 30000 ;; 30 seconds
+             :ring-handler user/route-handler}
 
   :auto {"compile-solidity" {:file-pattern #"\.(sol)$"
                              :paths ["resources/public/contracts/src"]}}

--- a/project.clj
+++ b/project.clj
@@ -169,7 +169,7 @@
                         :compiler {:main "name-bazaar.ui.core"
                                    :output-to "resources/public/js/compiled/app.js"
                                    :output-dir "resources/public/js/compiled/out"
-                                   :asset-path "js/compiled/out"
+                                   :asset-path "/js/compiled/out"
                                    :source-map-timestamp true
                                    :optimizations :none
                                    :preloads [print.foo.preloads.devtools

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -10,9 +10,9 @@
     <meta property="og:image:type" content="image/jpeg" />
 
     <meta id="description" name="description" content="A peer-to-peer marketplace for the exchange of names registered via the Ethereum Name Service."/>
-    <link rel="stylesheet" href="./css/semantic.min.css?v=14">
+    <link rel="stylesheet" href="/css/semantic.min.css?v=14">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-datepicker/0.55.0/react-datepicker.min.css">
-    <link rel="icon" href="./images/favicon.png">
+    <link rel="icon" href="/images/favicon.png">
 
     <script src="https://use.typekit.net/vwl3ovr.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>
@@ -21,7 +21,7 @@
 <body>
 <div id="app" style="height: 100%">
     <div style="display: flex; align-items: center; justify-content: center; height: 100%; padding: 10px">
-        <img style="width: 100%; max-width: 321px;" src="./images/bicycle.svg">
+        <img style="width: 100%; max-width: 321px;" src="/images/bicycle.svg">
     </div>
 </div>
 <script>
@@ -33,9 +33,9 @@
     ga('create', 'UA-100624852-3', 'auto');
 
 </script>
-<script src="./js/vendor/eth-ens-namehash.js"></script>
-<script src="./js/vendor/sha3.min.js"></script>
-<script src="./js/compiled/app.js?v=28"></script>
+<script src="/js/vendor/eth-ens-namehash.js"></script>
+<script src="/js/vendor/sha3.min.js"></script>
+<script src="/js/compiled/app.js?v=28"></script>
 <script>name_bazaar.ui.core.init();</script>
 <script>
     window.fbAsyncInit = function() {

--- a/src/name_bazaar/server/dev.cljs
+++ b/src/name_bazaar/server/dev.cljs
@@ -10,7 +10,7 @@
     [cljs.spec.alpha :as s]
     [district.server.config :refer [config]]
     [district.server.db :refer [db]]
-    [district.server.endpoints :as endpoints]
+    [district.server.endpoints]
     [district.server.endpoints.middleware.logging :refer [logging-middlewares]]
     [district.server.logging]
     [district.server.smart-contracts]


### PR DESCRIPTION
Fixes the client side router.

Now you can freely navigate to `http://localhost:4544/offering` and the correct URL will be server.
I also noticed that when you access an invalid page will result in `http://localhost:4544`

EDIT: Nested paths have been fixed according to https://github.com/quangv/re-frame-html5-routing/pull/1

How it works:
We serve the webpage and the resources (images, logos, css...) from the same route, `/`.
Whenever there is a request for an asset, we try to serve the asset (no modificatinon of request is done). You can verify this by trying to load a valid asset `http://localhost:4544/css/semantic.min.css` and invalid asset `http://localhost:4544/css/invalid_asset`.
For non-asset requests we will first try to serve the request and if the request is not found we will fallback and serve the `index.html`, which is exactly what we want.

TODO:
- [x] It doesn't work for nested URLs, like `http://localhost:4544/offerings/create`
- [x] I still need to understand what exactly is the ring handler doing