### PR TITLE
Only warn when a name cannot be resolved from public resolver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -111,7 +111,7 @@
                        [openzeppelin-solidity "2.3.0"]
                        [semantic-ui "2.4.1"]
                        [source-map-support "0.4.0"]
-                       [ws "2.0.1"]
+                       [ws "2.3.1"]
                        [xhr2 "0.1.4"]]
         :devDependencies [[ethlint "1.2.5"]
                           [karma "1.5.0"]

--- a/src/name_bazaar/ui/events/public_resolver_events.cljs
+++ b/src/name_bazaar/ui/events/public_resolver_events.cljs
@@ -52,19 +52,19 @@
             instance (get-instance db :public-resolver)
             args [node]]
 
-        ;; (prn instance)
-
         {:web3-fx.contract/constant-fns
          {:fns
           [{:instance instance
             :method :name
             :args args
             :on-success [:public-resolver.name/loaded addr]
-            :on-error [::logging/error "Failed to load name from public resolver" {:address addr
+            ;; If there is no mapping for the name in public resolver, an error will be triggered in web3
+            ;; https://ethereum.stackexchange.com/questions/1741/what-does-the-web3-bignumber-not-a-base-16-number-error-mean
+            ;; which is probably due to an old version of web3.
+            :on-error [::logging/warn "Failed to load name from public resolver. There is probably no mapping defined for this address." {:address addr
                                                                                    :contract {:name :public-resolver
                                                                                               :method :name
-                                                                                              :args args}}
-                       :public-resolver.name/load]}]}}))))
+                                                                                              :args args}}]}]}}))))
 
 (reg-event-fx
   :public-resolver.name/loaded


### PR DESCRIPTION
1) Updated the `ws` dependency, which was breaking at development for me.

2) Warn when a name cannot be resolved from public resolver
By removing `:public-resolver.name/load` from the arguments of the `on-error` callback I was able to print the stack trace of exception.

The error is `Uncaught BigNumber Error: new BigNumber() not a base 16 number:`, which is described in:
https://ethereum.stackexchange.com/questions/1741/what-does-the-web3-bignumber-not-a-base-16-number-error-mean

and is probably a result of using old web3, which fails to convert the value of non-existent mapping to string from public resolver:
https://github.com/ensdomains/resolvers/blob/339bf4376572358ae495449bba8352f3932bb0fe/contracts/profiles/NameResolver.sol#L29