### PR TITLE
Metamask related fixes

### DIFF
--- a/compile-solidity.sh
+++ b/compile-solidity.sh
@@ -3,7 +3,7 @@
 # TODO find a way to specify node_modules as an additional source root for solc
 # TODO or migrate to truffle and the entire compilation workflow will be changed
 ENS=$(readlink -f ./node_modules/@ensdomains)
-OZS=$(readlink -f ./node_modules/@ensdomains/ethregistrar/node_modules/openzeppelin-solidity)
+OZS=$(readlink -f ./node_modules/openzeppelin-solidity)
 
 cd resources/public/contracts/src
 

--- a/resources/public/contracts/src/Offering.sol
+++ b/resources/public/contracts/src/Offering.sol
@@ -176,11 +176,13 @@ contract Offering {
     function doTransferOwnership(address payable _newOwner)
         private
     {
-        ens.setOwner(offering.node, _newOwner);
         if (isNodeTLDOfRegistrar()) {
             uint256 tokenId = uint256(offering.labelHash);
             BaseRegistrar registrar = BaseRegistrar(ens.owner(rootNode));
+            registrar.reclaim(tokenId, _newOwner);
             registrar.transferFrom(registrar.ownerOf(tokenId), _newOwner, tokenId);
+        } else {
+            ens.setOwner(offering.node, _newOwner);
         }
     }
 
@@ -209,7 +211,7 @@ contract Offering {
         if (isNodeTLDOfRegistrar()) {
             uint256 tokenId = uint256(offering.labelHash);
             address registrationOwner = BaseRegistrar(ens.owner(rootNode)).ownerOf(tokenId);
-            return ens.owner(offering.node) == address(this) && registrationOwner == address(this);
+            return registrationOwner == address(this);
         } else {
             return ens.owner(offering.node) == address(this);
         }

--- a/src/name_bazaar/server/contracts_api/registrar.cljs
+++ b/src/name_bazaar/server/contracts_api/registrar.cljs
@@ -17,18 +17,21 @@
                         opts)))
 
 (defn transfer! [{:keys [:ens.record/label :ens.record/owner]} & [opts]]
-  {:set-owner-tx
-     (ens/set-owner! {:ens.record/name (str label ".eth")
-                      :ens.record/owner owner}
-                     opts)
-   :transfer-tx
-     (contract-call :name-bazaar-registrar
-                    :transferFrom
-                    (:from opts)
-                    owner
-                    (sha3 label)
-                    (merge {:gas 2000000}
-                           opts))})
+  (contract-call :name-bazaar-registrar
+                 :transfer-from
+                 (:from opts)
+                 owner
+                 (sha3 label)
+                 (merge {:gas 2000000}
+                        opts)))
+
+(defn reclaim! [{:keys [:ens.record/label :ens.record/owner]} & [opts]]
+  (contract-call :name-bazaar-registrar
+                 :reclaim
+                 (sha3 label)
+                 owner
+                 (merge {:gas 2000000}
+                        opts)))
 
 (defn registration-owner [{:keys [:ens.record/hash :ens.record/label]}]
   (contract-call :name-bazaar-registrar :owner-of (sha3 label hash)))

--- a/src/name_bazaar/server/contracts_api/registrar.cljs
+++ b/src/name_bazaar/server/contracts_api/registrar.cljs
@@ -36,3 +36,5 @@
 (defn ens []
   (contract-call :name-bazaar-registrar :ens))
 
+(defn on-transfer [& args]
+  (apply contract-call :name-bazaar-registrar :Transfer args))

--- a/src/name_bazaar/server/dev.cljs
+++ b/src/name_bazaar/server/dev.cljs
@@ -73,6 +73,7 @@
                             :endpoints {:port 6200
                                         :middlewares [logging-middlewares]}
                             :web3 {:port 8549}
+                            :db {:opts {:memory true}}
                             :emailer {:print-mode? true
                                       :private-key "25677d268904ea651f84e37cfd580696c5c793dcd9730c415bf03b96003c09e9ef8"}
                             :ui {:public-key "2564e15aaf9593acfdc633bd08f1fc5c089aa43972dd7e8a36d67825cd0154602da47d02f30e1f74e7e72c81ba5f0b3dd20d4d4f0cc6652a2e719a0e9d4c7f10943"

--- a/src/name_bazaar/ui/events.cljs
+++ b/src/name_bazaar/ui/events.cljs
@@ -194,19 +194,19 @@
   :name/transfer-ownership
   interceptors
   (fn [{:keys [:db]} [name owner]]
-    {:dispatch
-     (if (top-level-name? name)
-       [:name-bazaar-registrar/transfer {:ens.record/label (name-label name)
-                                         :ens.record/owner owner}
-        {:result-href (path-for :route.ens-record/detail {:ens.record/name name})
-         :on-tx-receipt-n [[:ens.records/load [(namehash name)]
-                            {:load-resolver? true}]
-                           [:district0x.snackbar/show-message
-                            (gstring/format "Ownership of %s was transferred to %s"
-                                            name
-                                            (truncate owner 10))]]}]
-       [:ens/set-owner {:ens.record/name name
-                        :ens.record/owner owner}])}))
+    {:dispatch-n
+      [[:ens/set-owner {:ens.record/name name
+                        :ens.record/owner owner}]
+       (if (top-level-name? name)
+         [:name-bazaar-registrar/transfer {:ens.record/label (name-label name)
+                                           :ens.record/owner owner}
+          {:result-href (path-for :route.ens-record/detail {:ens.record/name name})
+           :on-tx-receipt-n [[:ens.records/load [(namehash name)]
+                             {:load-resolver? true}]
+                             [:district0x.snackbar/show-message
+                              (gstring/format "Ownership of %s was transferred to %s"
+                                              name
+                                              (truncate owner 10))]]}])]}))
 
 (reg-event-fx
   :saved-searches/add

--- a/src/name_bazaar/ui/events/offerings_events.cljs
+++ b/src/name_bazaar/ui/events/offerings_events.cljs
@@ -652,16 +652,17 @@
   :offerings/transfer-ownership
   interceptors
   (fn [{:keys [:db]} [name owner]]
-    {:dispatch-n
-      [[:ens/set-owner {:ens.record/name name
-                        :ens.record/owner owner}]
-       (if (top-level-name? name)
-         [:name-bazaar-registrar/transfer {:ens.record/label (name-label name)
-                                           :ens.record/owner owner}
-          {:result-href (path-for :route.offerings/detail {:offering/address owner})
-           :on-tx-receipt-n [[:offerings.ownership/load [owner]]
-                             [:district0x.snackbar/show-message
-                              (gstring/format "Ownership of %s was transferred" name)]]}])]}))
+    {:dispatch
+      (conj
+        (if (top-level-name? name)
+          [:name-bazaar-registrar/transfer {:ens.record/label (name-label name)
+                                            :ens.record/owner owner}]
+          [:ens/set-owner {:ens.record/name name
+                           :ens.record/owner owner}])
+        {:result-href (path-for :route.offerings/detail {:offering/address owner})
+         :on-tx-receipt-n [[:offerings.ownership/load [owner]]
+                           [:district0x.snackbar/show-message
+                            (gstring/format "Ownership of %s was transferred" name)]]})}))
 
 (reg-event-fx
   :offerings.total-count/loaded

--- a/src/name_bazaar/ui/pages/ens_record_detail_page.cljs
+++ b/src/name_bazaar/ui/pages/ens_record_detail_page.cljs
@@ -7,6 +7,7 @@
     [name-bazaar.ui.components.offering.infinite-list :refer [offering-infinite-list]]
     [name-bazaar.ui.components.offering.list-item :refer [offering-list-item]]
     [name-bazaar.ui.components.offering.offerings-order-by-select :refer [offerings-order-by-select]]
+    [name-bazaar.ui.utils :refer [name->label-hash]]
     [name-bazaar.shared.utils :refer [name-label top-level-name?]]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]

--- a/src/name_bazaar/ui/subs/offerings_subs.cljs
+++ b/src/name_bazaar/ui/subs/offerings_subs.cljs
@@ -142,15 +142,13 @@
      (subscribe [:offering/ens-record offering-address])
      (subscribe [:offering/registrar-registration offering-address])])
   (fn [[{:keys [:offering/top-level-name?]} ens-record registrar-registration] [_ offering-address]]
-    (when (and (:ens.record/owner ens-record)
-               (if top-level-name?
-                 (:name-bazaar-registrar.registration/owner registrar-registration)
-                 true))
-      (= offering-address
-         (:ens.record/owner ens-record)
-         (if top-level-name?
-           (:name-bazaar-registrar.registration/owner registrar-registration)
-           offering-address)))))
+    (when
+      (if top-level-name?
+        (:name-bazaar-registrar.registration/owner registrar-registration)
+        (:ens.record/owner ens-record))
+      (if top-level-name?
+        (= offering-address (:name-bazaar-registrar.registration/owner registrar-registration))
+        (= offering-address (:ens.record/owner ens-record))))))
 
 (reg-sub
   :offering/missing-ownership?

--- a/src/name_bazaar/ui/subs/offerings_subs.cljs
+++ b/src/name_bazaar/ui/subs/offerings_subs.cljs
@@ -142,13 +142,10 @@
      (subscribe [:offering/ens-record offering-address])
      (subscribe [:offering/registrar-registration offering-address])])
   (fn [[{:keys [:offering/top-level-name?]} ens-record registrar-registration] [_ offering-address]]
-    (when
-      (if top-level-name?
-        (:name-bazaar-registrar.registration/owner registrar-registration)
-        (:ens.record/owner ens-record))
-      (if top-level-name?
-        (= offering-address (:name-bazaar-registrar.registration/owner registrar-registration))
-        (= offering-address (:ens.record/owner ens-record))))))
+    (let [node-owner (if top-level-name?
+                       (:name-bazaar-registrar.registration/owner registrar-registration)
+                       (:ens.record/owner ens-record))]
+      (and node-owner (= offering-address node-owner)))))
 
 (reg-sub
   :offering/missing-ownership?

--- a/src/name_bazaar/ui/utils.cljs
+++ b/src/name_bazaar/ui/utils.cljs
@@ -38,6 +38,9 @@
 (defn valid-ens-subname? [subname]
   (and subname (valid-ens-name? subname) (not (string/includes? subname "."))))
 
+(defn valid-ens-subname? [subname]
+  (and subname (valid-ens-name? subname) (not (string/includes? subname "."))))
+
 (defn ensure-registrar-root [name]
   (if-not (string/ends-with? name constants/registrar-root)
     (str name constants/registrar-root)

--- a/test/server/name_bazaar/smart_contract_altering_tests.cljs
+++ b/test/server/name_bazaar/smart_contract_altering_tests.cljs
@@ -72,10 +72,6 @@
             (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
                                      {:from addr1})))
 
-          (testing "The name ownership must be transferred to the offering"
-            (is (= offering (ens/owner {:ens.record/node (namehash
-                                                           "abc.eth")}))))
-
           (testing "Ensuring offering gets the registration"
             (is (= offering (registrar/registration-owner {:ens.record/label "abc"}))))
           (testing "For Buy Now offering, original owner can reclaim ENS name ownership (for TLD also registration ownership)"
@@ -158,9 +154,6 @@
             (testing "Transferring ownership to the offering"
               (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
                                        {:from addr1})))
-
-            (testing "The name ownership must be transferred to the offering"
-              (is (= offering (ens/owner {:ens.record/node (namehash "abc.eth")}))))
 
             (testing "Ensuring offering gets the registration"
               (is (= offering (registrar/registration-owner {:ens.record/label "abc"}))))
@@ -249,9 +242,6 @@
           (testing "Transferring ownership to the offering"
             (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
                                      {:from addr1})))
-
-          (testing "The name ownership must be transferred to the offering"
-            (is (= offering (ens/owner {:ens.record/node (namehash "abc.eth")}))))
 
           (testing "Ensuring offering gets the registration"
             (is (= offering (registrar/registration-owner {:ens.record/label "abc"}))))


### PR DESCRIPTION
Both buy now and auction offerings should now work with both HD wallet and Metamask, for TLD and non-TLD names.

We replaced the workflow of transferring ownership into Offering contract in two transactions by doing it in one. This is how it originally was, but of course we now need to be supporting registrar token transfers for TLDs.

We do it as follows: for non-TLD names, registry ownership is passed around. For TLD names, registrar token is passed around. As a courtesy, whenever transferring onto end user (buy in buy now offering, auction finalization, reclaim back when taking our auction down...), the Offering contract obtains registry ownership too and passes it to the end user.